### PR TITLE
Make test object accessible via ID through Mojito.getTest()

### DIFF
--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -1554,13 +1554,13 @@ Mojito = (function ()
             }
 
             var testObject = new Test(testConfig);
-            this.testObjects[testConfig.name] = testObject;
+            this.testObjects[testConfig.id] = testObject;
 
             return testObject;
         },
-        getTest: function (name)
+        getTest: function (id)
         {
-            return this.testObjects[name];
+            return this.testObjects[id];
         },
         Test: Test,
         Cookies: Cookies,

--- a/tests/test_suite.html
+++ b/tests/test_suite.html
@@ -92,6 +92,10 @@
         it('Plain test activates', function () {
             w1NewToTest.should.equal(true);
         });
+        var w1GetTestState = Mojito.getTest('w1').options.state;
+        it('Plain test accessible via .getTest()', function () {
+            w1GetTestState.should.equal('live');
+        });
         it('Exposure event fired', function () {
             exposureIsTracked('unit_test_new').should.equal(true);
         });

--- a/tests/test_suite.html
+++ b/tests/test_suite.html
@@ -92,8 +92,8 @@
         it('Plain test activates', function () {
             w1NewToTest.should.equal(true);
         });
-        var w1GetTestState = Mojito.getTest('w1').options.state;
         it('Plain test accessible via .getTest()', function () {
+            var w1GetTestState = Mojito.getTest('w1').options.state;
             w1GetTestState.should.equal('live');
         });
         it('Exposure event fired', function () {


### PR DESCRIPTION
Currently the Mojito.getTest() function expects to see the test object's name. However I think it's more intuitive for us to use the ID to reference test objects.

This PR changes that behaviour. Any thoughts on this guys?