### PR TITLE
Change divertTo to only run when test is live

### DIFF
--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -181,11 +181,12 @@ Mojito = (function ()
                 var inTest = this.inTest(),
                     newToThisTest = false,
                     excludeBySample = false,
-                    divertTo = this.options.divertTo;
+                    divertTo = this.options.divertTo,
+                    isLive = this.options.state.toLowerCase() == OBJECT_STATES.LIVE;
 
                 // handle 'divertTo', if 'divertTo' is set then Send all traffic to the winning treatment and disable tracking
-                // if divertTo is set and valid, run recipe, then stop
-                if (divertTo && Utils.arrayIndexOf(this.recipes, divertTo) >= 0)
+                // if the test is live and divertTo is set and valid, run recipe, then stop
+                if (isLive && divertTo && Utils.arrayIndexOf(this.recipes, divertTo) >= 0)
                 {
                     this.log("Test Object [" + this.options.name + "][" + this.options.id + "] was diverted to " + divertTo + ".");
                     this.options.isDivert = true;
@@ -194,7 +195,7 @@ Mojito = (function ()
                     return success;
                 }
 
-                if (inTest === null && this.options.state.toLowerCase() == OBJECT_STATES.LIVE)
+                if (inTest === null && isLive)
                 {
                     inTest = (this.options.sampleRate <= 0) ? false : (this.getRandom() <= this.options.sampleRate);
 

--- a/tests/test_suite.html
+++ b/tests/test_suite.html
@@ -137,6 +137,7 @@
             id: 'w1',
             state: 'staging',
             name: 'unit_test_staging_mode',
+            divertTo: '0',
             sampleRate: 1,
             trigger: function (e) {
                 e.activate();


### PR DESCRIPTION
Based on the test activation logic, divertTo will activate the test for users even when set to `staging`.

I understand we don't use `divertTo` frequently in `staging` mode, but I think that may be confusing to users. If `staging` may be used for development and preview of tests before they are published, we should protect users. 

This PR makes divertTo respect `live`/`staging` modes.