### PR TITLE
Remove unused testScope variables

### DIFF
--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -22,13 +22,6 @@ Mojito = (function ()
         defaultWaitTimeout: 2000
     };
 
-    // test scope definition
-    var TEST_SCOPE = {
-        USER: "user",
-        SESSION: "session",
-        HIT: "hit"
-    };
-
     // test object states
     var OBJECT_STATES = {
         STAGING: 'staging',
@@ -51,7 +44,6 @@ Mojito = (function ()
                 id: null,
                 name: null,
                 recipes: null,
-                testScope: TEST_SCOPE.USER,
                 sampleRate: 1.0,
                 storageAdapter: null,
                 trigger: null
@@ -181,11 +173,12 @@ Mojito = (function ()
                 var inTest = this.inTest(),
                     newToThisTest = false,
                     excludeBySample = false,
-                    divertTo = this.options.divertTo;
+                    divertTo = this.options.divertTo,
+                    isLive = this.options.state.toLowerCase() == OBJECT_STATES.LIVE;
 
                 // handle 'divertTo', if 'divertTo' is set then Send all traffic to the winning treatment and disable tracking
-                // if divertTo is set and valid, run recipe, then stop
-                if (divertTo && Utils.arrayIndexOf(this.recipes, divertTo) >= 0)
+                // if the test is live and divertTo is set and valid, run recipe, then stop
+                if (isLive && divertTo && Utils.arrayIndexOf(this.recipes, divertTo) >= 0)
                 {
                     this.log("Test Object [" + this.options.name + "][" + this.options.id + "] was diverted to " + divertTo + ".");
                     this.options.isDivert = true;
@@ -194,7 +187,7 @@ Mojito = (function ()
                     return success;
                 }
 
-                if (inTest === null && this.options.state.toLowerCase() == OBJECT_STATES.LIVE)
+                if (inTest === null && isLive)
                 {
                     inTest = (this.options.sampleRate <= 0) ? false : (this.getRandom() <= this.options.sampleRate);
 
@@ -507,7 +500,7 @@ Mojito = (function ()
                 if (!val)
                 {
                     val = "mjt" + (new Date).getTime() + "r" + Math.random();
-                    Cookies.set('mojitoEndUserId', val, null, this.options.testScope, this.options.options.cookieDomain)
+                    Cookies.set('mojitoEndUserId', val, null, this.options.options.cookieDomain)
                 }
 
                 return val;


### PR DESCRIPTION
I don't think this testScope is being used any longer. 

If we go down the route of specifying the unit with deterministic assignment, we can specify the unit per test there. And really, most tests are user-based, anyway.

I'm not missing anything here, am I @allmywant? Removing this feature allowed all tests to pass fine. The only use for it seems to be in the function for setting the user ID cookie with `this.options.testScope`:

```js
            _getEndUserId: function()
            {
                var val = Cookies.get('mojitoEndUserId');

                if (!val)
                {
                    val = "mjt" + (new Date).getTime() + "r" + Math.random();
                    Cookies.set('mojitoEndUserId', val, null, this.options.testScope, this.options.options.cookieDomain)
                }

                return val;
            },
```