### PR TITLE
Exclude YAML private key from JSON output

### DIFF
--- a/scripts/modular-build.js
+++ b/scripts/modular-build.js
@@ -52,6 +52,11 @@ function buildTest(file, stream, buildResult)
 
 		waves[testObject.id] = `${dirname}${path.sep}config.yml`;
 
+		// remove private data from publishing
+		if (testObject.private) {
+			delete testObject.private;
+		}
+
 		if (testObject.state == 'live')
 		{
 			if (testObject.divertTo != null)


### PR DESCRIPTION
As per #18 - we can use this for future features like:

* Editor URL (for screenshots / automated testing / generating preview links)
* Tags (for grouping tests e.g. publish only "checkout" tests)
* Other test data we don't want public

