### PR TITLE
Publish containers in parallel to S3

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,8 @@ const gulp = require('gulp'),
     zlib = require('zlib'),
     babel = require('gulp-babel'),
     newCli = require('./scripts/cli-new'),
-    setCli = require('./scripts/cli-set');
+    setCli = require('./scripts/cli-set'),
+    parallelize = require('concurrent-transform');
     
 // Check whether config exists & create it if not.
 for (const file of ['config.js', 'lib/shared-code.js'])
@@ -171,8 +172,8 @@ function publish()
 
     return (
         gulp.src("dist/assets/js/*.js")
-            .pipe(awspublish.gzip())
-            .pipe(publisher.publish(headers, { force: true }))
+            .pipe(parallelize(awspublish.gzip(), 5))
+            .pipe(parallelize(publisher.publish(headers, { force: true }), 5))
             .pipe(awspublish.reporter())
     );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1830,6 +1830,11 @@
         "source-map": "^0.6.1"
       }
     },
+    "concurrent-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/concurrent-transform/-/concurrent-transform-1.0.0.tgz",
+      "integrity": "sha1-eg/eovgJYjlIf9sK3bXtqn9Zb2w="
+    },
     "convert-source-map": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,5 +22,7 @@
     "should": "^13.2.3",
     "through2": "^3.0.1"
   },
-  "dependencies": {}
+  "dependencies": {
+    "concurrent-transform": "^1.0.0"
+  }
 }


### PR DESCRIPTION
Publishing the containers asynchronously speeds things up by ~40% for the upload:

```
$ echo "Before parallel" && repeat 10 gulp publish | grep Finished
Before parallel
[23:07:32] Finished 'publish' after 942 ms
[23:07:34] Finished 'publish' after 844 ms
[23:07:36] Finished 'publish' after 849 ms
[23:07:37] Finished 'publish' after 805 ms
[23:07:39] Finished 'publish' after 859 ms
[23:07:41] Finished 'publish' after 845 ms
[23:07:43] Finished 'publish' after 792 ms
[23:07:45] Finished 'publish' after 863 ms
[23:07:47] Finished 'publish' after 976 ms
[23:07:49] Finished 'publish' after 819 ms
```

```
$ echo "After parallel" && repeat 10 gulp publish | grep Finished
After parallel
[23:09:12] Finished 'publish' after 526 ms
[23:09:13] Finished 'publish' after 501 ms
[23:09:15] Finished 'publish' after 484 ms
[23:09:16] Finished 'publish' after 524 ms
[23:09:18] Finished 'publish' after 562 ms
[23:09:19] Finished 'publish' after 463 ms
[23:09:21] Finished 'publish' after 509 ms
[23:09:22] Finished 'publish' after 519 ms
[23:09:24] Finished 'publish' after 489 ms
[23:09:25] Finished 'publish' after 453 ms
```

Partially solves #73 