### PR TITLE
Add gulp refresh command

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -195,3 +195,4 @@ exports.publish = publish;
 exports.default = build;
 exports.new = cliNew;
 exports.set = cliSet;
+exports.refresh = gulp.series([build, publish]);


### PR DESCRIPTION
Addressing #73 - this adds the Gulp refresh command:

```sh
$ gulp refresh
[22:39:56] Using gulpfile ~/Documents/github/mojito-js-delivery/gulpfile.js
[22:39:56] Starting 'refresh'...
[22:39:56] Starting 'build'...
[22:39:58] Finished 'build' after 2.21 s
[22:39:58] Starting 'publish'...
Mojito container built (5.20 KB)
[22:39:59] [update] mojito.js
[22:39:59] [update] mojito.pretty.js
[22:39:59] Finished 'publish' after 580 ms
[22:39:59] Finished 'refresh' after 2.8 s
```

Then we can automatically build the container on changes. e.g. like with entr:

```sh
$ find lib/** | entr gulp refresh
```