### PR TITLE
Update licenses to 2021

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019, Mint Metrics Pty Ltd. All rights reserved.
+Copyright (c) 2021, Mint Metrics Pty Ltd. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/license.txt
+++ b/license.txt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, Mint Metrics Pty Ltd All rights reserved. BSD 3-Clause License. https://github.com/mint-metrics/mojito/blob/master/LICENSE
+ * Copyright (c) 2021, Mint Metrics Pty Ltd All rights reserved. BSD 3-Clause License. https://github.com/mint-metrics/mojito/blob/master/LICENSE
  * Copyright (c) 2010, James Yu. https://github.com/jamesyu/cohorts/blob/master/LICENSE
  * Copyright (c) 2005-2017, JS Foundation All rights reserved. https://dojotoolkit.org/license.html
  * Copyright (c) 2011 Sebastian Tschan, https://blueimp.net


### PR DESCRIPTION
This is just to keep the licenses current - we hadn't updated these since 2019.