### PR TITLE
Require sampleRate property when used on at least one recipe

### DIFF
--- a/wave.schema.json
+++ b/wave.schema.json
@@ -69,7 +69,8 @@
                             "maximum": 1
                         }
                     },
-                    "additionalProperties": false
+                    "additionalProperties": false,
+                    "required": ["name"]
                 }
             },
             "additionalProperties": false
@@ -116,9 +117,6 @@
                 "recipes": {
                     "patternProperties": {
                         "^[a-zA-Z0-9]+$": {
-                            "properties": {
-                                "sampleRate": {}
-                            },
                             "required": ["sampleRate"]
                         }
                     }

--- a/wave.schema.json
+++ b/wave.schema.json
@@ -110,5 +110,33 @@
         }
     },
     "required": ["id", "name", "recipes", "state", "sampleRate", "trigger"],
-    "additionalProperties": true
+    "additionalProperties": true,
+    "oneOf": [{
+            "properties": {
+                "recipes": {
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "properties": {
+                                "sampleRate": {}
+                            },
+                            "required": ["sampleRate"]
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "properties": {
+                "recipes": {
+                    "patternProperties": {
+                        "^[a-zA-Z0-9]+$": {
+                            "not": {
+                                "required": ["sampleRate"]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
 }


### PR DESCRIPTION
Addressing the YAML validation proposed to address #91 

When editing the experiment YAML to add a sampleRate property to one recipe object, but not others, it will fail the YAML:

<img width="998" alt="Schema validation on Mojito recipes object with sampleRate" src="https://user-images.githubusercontent.com/2361388/111301318-2f3aae00-86a6-11eb-8fc5-5d3d5b194765.png">

[When VS Code is configured to validate test YAMLs](https://dev.to/brpaz/how-to-create-your-own-auto-completion-for-json-and-yaml-files-on-vs-code-with-the-help-of-json-schema-k1i), it should make it clear in the UI after adding:

<img width="223" alt="Screen Shot 2021-03-16 at 10 28 02 pm" src="https://user-images.githubusercontent.com/2361388/111301936-e2a3a280-86a6-11eb-927b-371cba13e348.png">
