### PR TITLE
Lint templates used in gulp new aa/ab/demo command

### DIFF
--- a/scripts/cli-new.js
+++ b/scripts/cli-new.js
@@ -127,14 +127,14 @@ function createABTest(waveId, cb)
     fs.writeFileSync(waveFolder + '/config.yml', yaml.dump(test));
     // recipe js
     let content =
-        `function treatment(test) {
+        `function treatment (test) {
     console.log('Test id: ' + test.options.id, ', name: ' + test.options.name, ', chosen recipe: ' + test.chosenRecipe.id);
 }`;
     fs.writeFileSync(waveFolder + '/1.js', content);
 
     // trigger
     content =
-        `function trigger(test) {
+        `function trigger (test) {
     Mojito.utils.domReady(test.activate);
 }`;
     fs.writeFileSync(waveFolder + '/trigger.js', content);
@@ -171,7 +171,7 @@ function createDemoTest(waveId, cb)
     fs.writeFileSync(waveFolder + '/config.yml', yaml.dump(test));
     // recipe js
     let content =
-        `function treatment(test) {
+        `function treatment (test) {
     console.log('Test id: ' + test.options.id, ', name: ' + test.options.name, ', chosen recipe: ' + test.chosenRecipe.id);
 }`;
     fs.writeFileSync(waveFolder + '/1.js', content);
@@ -184,7 +184,7 @@ function createDemoTest(waveId, cb)
 
     // trigger
     content =
-        `function trigger(test) {
+        `function trigger (test) {
     Mojito.utils.domReady(test.activate);
 }`;
     fs.writeFileSync(waveFolder + '/trigger.js', content);
@@ -219,8 +219,8 @@ function createAATest(waveId, cb)
     fs.writeFileSync(waveFolder + '/config.yml', yaml.dump(test));
     // trigger
     let content =
-        `function trigger(test) {
-    Mojito.utils.domReady(test.activate);
+        `function trigger (test) {
+    test.activate();
 }`;
     fs.writeFileSync(waveFolder + '/trigger.js', content);
 


### PR DESCRIPTION
This is a really small PR that just lints the templates' JS for `gulp new`. More addressing an annoyance when generating tests.

It also changes the AA test trigger to remove `Mojito.utils.domReady()`.

### Before

Warning for `space-before-function-paren` triggered:

<img width="260" alt="Screen Shot 2021-07-01 at 14 33 12" src="https://user-images.githubusercontent.com/2361388/124065018-4648b480-da79-11eb-83c1-de0c38c25efa.png">


### After

<img width="269" alt="Screen Shot 2021-07-01 at 14 33 39" src="https://user-images.githubusercontent.com/2361388/124065065-552f6700-da79-11eb-9f75-d40d6848a245.png">
