### PR TITLE
Fix: Set Pipelines npm config to root user

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -31,6 +31,7 @@ pipelines:
             - node
           script:
             - npm ci
+            - npm -g config set user root
             - npm install -g gulp-cli
             - gulp ssa --state $State --waveId $WaveId --traffic $SampleRate --recipe $RecipeToDivertTo
             - git add --all
@@ -46,6 +47,7 @@ pipelines:
             - node
           script:
             - npm ci
+            - npm -g config set user root
             - npm install -g gulp-cli
             - gulp build
             - gulp publish --awsk $AWS_ACCESS_KEY_ID --awss $AWS_SECRET_ACCESS_KEY --production
@@ -68,6 +70,7 @@ pipelines:
             - node
           script:
             - npm ci
+            - npm -g config set user root
             - npm install -g gulp-cli
             - gulp build
             - gulp publish --awsk $AWS_ACCESS_KEY_ID --awss $AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
On new Bitbucket Pipelines docker images, builds now fail when installing gulp as a global package:

```
npm install -g gulp-cli
```

With error message:

```
sh: 1: node: Permission denied
npm ERR! Maximum call stack size exceeded
```

Specifying `npm -g config set user root` before installing global packages fixes this issue.
