### PR TITLE
Bump pipelines image to Atlassian default:4

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,4 +1,4 @@
-image: atlassian/default-image:3
+image: atlassian/default-image:4
 
 pipelines:
   custom:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mojito-js-delivery",
-  "version": "2.3.1",
+  "version": "2.4.1",
   "description": "Utilities to build, launch and measure split tests. Part of the Mojito framework.",
   "devDependencies": {
     "@babel/core": "^7.14.3",


### PR DESCRIPTION
It looks like there's a new Atlassian default image available. I wonder if this newer image will help us address some of the random pipeline failures we've been seeing lately?

<img width="820" alt="Screenshot 2023-07-18 at 09 02 57" src="https://github.com/mint-metrics/mojito-js-delivery/assets/2361388/840360f4-2f3b-4962-aeeb-65397d8812d5">

What do you guys think?